### PR TITLE
fixes #9: Core Client Threadpool MBean registration fails when server is restarted

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -42,6 +42,12 @@
 <h1>
 </h1>
 
+<p><b>0.9.1</b> -- (tbd)</p>
+<ul>
+    <li>[<a href="https://github.com/igniterealtime/openfire-jmxweb-plugin/issues/9">#9</a>] - Core Client Threadpool MBean registration fails when server is restarted.</li>
+</ul>
+
+
 <p><b>0.9.0</b> -- May 21, 2021</p>
 
 <ul>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
     <description>JmxWeb plugin is web based platform for managing and monitoring openfire via JMX.</description>
     <version>${project.version}</version>
     <licenseType>Apache 2.0</licenseType>    
-    <date>05/09/2018</date>
+    <date>08/04/2021</date>
     <minServerVersion>4.3.0</minServerVersion>
     <minJavaVersion>1.8</minJavaVersion>
     <author>igniterealtime.org</author>


### PR DESCRIPTION
Makes registration of the core client threadpool asynchronous, waiting for the socketacceptor that's need to become available.

The maximum duration of this wait can be controlled with a new property `jmxweb.socket-acceptor.max-init-duration` which takes a duration in milliseconds (defaults to 10 minutes).